### PR TITLE
fix: correct events route mounting

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -29,7 +29,8 @@ app.use(express.urlencoded({ extended: true }));
 
 // Routes
 app.use("/auth", authRoutes);
-app.use("/api", eventRoutes);
+// Event routes are mounted under /api/events
+app.use("/api/events", eventRoutes);
 
 // Health check
 app.get("/health", (req, res) => {

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -9,8 +9,9 @@ const router = Router();
 const googleCalendarService = new GoogleCalendarService();
 
 // Get events with date filtering
+// Mounted at /api/events in the server
 router.get(
-  "/events",
+  "/",
   authenticateToken,
   [query("days").optional().isInt({ min: 1, max: 365 }), query("startDate").optional().isISO8601()],
   async (req: AuthRequest, res) => {
@@ -56,8 +57,9 @@ router.get(
 );
 
 // Create new event
+// Mounted at /api/events in the server
 router.post(
-  "/events",
+  "/",
   authenticateToken,
   [
     body("title").notEmpty().withMessage("Title is required"),
@@ -107,7 +109,8 @@ router.post(
 );
 
 // Refresh events from Google Calendar
-router.post("/events/refresh", authenticateToken, async (req: AuthRequest, res) => {
+// Mounted at /api/events in the server
+router.post("/refresh", authenticateToken, async (req: AuthRequest, res) => {
   try {
     const user = req.user!;
 


### PR DESCRIPTION
## Summary
- fix events router paths to avoid duplicate `/events` segments
- mount event routes under `/api/events` in server index

## Testing
- `npm test` *(fails: Missing script: "test" on backend)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: various TypeScript errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c197539d808321ae4274b08ec80a94